### PR TITLE
Add Automatise Plugin

### DIFF
--- a/automatise-plugin/README.md
+++ b/automatise-plugin/README.md
@@ -1,0 +1,12 @@
+# Automatise Plugin
+
+A simple WordPress plugin that provides site appearance settings, custom page fields (using ACF), automatic page creation, and indexing settings.
+
+## Installation
+1. Copy the `automatise-plugin` folder into your WordPress `wp-content/plugins` directory.
+2. Activate the plugin from the WordPress admin plugins screen.
+
+## Features
+- Settings page under **Settings > Site Appearance** for uploading a logo, favicon, and selecting primary and secondary colors.
+- Custom fields for pages: title, description, content, FAQ, and game block (requires the Advanced Custom Fields plugin).
+- Automatically creates basic pages (`Home`, `About`, and `Contact`) on activation and ensures they are indexed by search engines.

--- a/automatise-plugin/automatise-plugin.php
+++ b/automatise-plugin/automatise-plugin.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Plugin Name: Automatise Plugin
+ * Description: Adds site settings, custom page fields, and page creation with indexing.
+ * Version: 1.0.0
+ * Author: Codex
+ * Text Domain: automatise-plugin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+// Include required files.
+require_once plugin_dir_path( __FILE__ ) . 'includes/settings.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/acf-fields.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/pages.php';
+
+// Activation hook to create pages and enable indexing.
+register_activation_hook( __FILE__, 'ap_activate_plugin' );

--- a/automatise-plugin/includes/acf-fields.php
+++ b/automatise-plugin/includes/acf-fields.php
@@ -1,0 +1,65 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class AP_ACF_Fields {
+
+    public function __construct() {
+        add_action( 'acf/init', array( $this, 'register_fields' ) );
+    }
+
+    public function register_fields() {
+        if ( ! function_exists( 'acf_add_local_field_group' ) ) {
+            return;
+        }
+
+        acf_add_local_field_group( array(
+            'key' => 'group_ap_page_fields',
+            'title' => __( 'Page Custom Fields', 'automatise-plugin' ),
+            'fields' => array(
+                array(
+                    'key' => 'field_ap_page_title',
+                    'label' => __( 'Title', 'automatise-plugin' ),
+                    'name' => 'ap_page_title',
+                    'type' => 'text',
+                ),
+                array(
+                    'key' => 'field_ap_page_description',
+                    'label' => __( 'Description', 'automatise-plugin' ),
+                    'name' => 'ap_page_description',
+                    'type' => 'textarea',
+                ),
+                array(
+                    'key' => 'field_ap_page_content',
+                    'label' => __( 'Content', 'automatise-plugin' ),
+                    'name' => 'ap_page_content',
+                    'type' => 'wysiwyg',
+                ),
+                array(
+                    'key' => 'field_ap_page_faq',
+                    'label' => __( 'FAQ', 'automatise-plugin' ),
+                    'name' => 'ap_page_faq',
+                    'type' => 'wysiwyg',
+                ),
+                array(
+                    'key' => 'field_ap_page_game',
+                    'label' => __( 'Game Block', 'automatise-plugin' ),
+                    'name' => 'ap_page_game_block',
+                    'type' => 'wysiwyg',
+                ),
+            ),
+            'location' => array(
+                array(
+                    array(
+                        'param' => 'post_type',
+                        'operator' => '==',
+                        'value' => 'page',
+                    ),
+                ),
+            ),
+        ) );
+    }
+}
+
+new AP_ACF_Fields();

--- a/automatise-plugin/includes/pages.php
+++ b/automatise-plugin/includes/pages.php
@@ -1,0 +1,33 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function ap_activate_plugin() {
+    $pages = array( 'home', 'about', 'contact' );
+    foreach ( $pages as $slug ) {
+        $existing = get_page_by_path( $slug );
+        if ( ! $existing ) {
+            wp_insert_post( array(
+                'post_title'   => ucfirst( $slug ),
+                'post_name'    => $slug,
+                'post_status'  => 'publish',
+                'post_type'    => 'page',
+            ) );
+        }
+    }
+
+    // Ensure indexing is enabled
+    update_option( 'blog_public', 1 );
+}
+add_action( 'wp_head', 'ap_add_index_meta' );
+function ap_add_index_meta() {
+    echo "\n<meta name='robots' content='index, follow'>\n";
+}
+
+add_action( 'save_post_page', 'ap_set_page_indexing', 10, 3 );
+function ap_set_page_indexing( $post_ID, $post, $update ) {
+    if ( 'publish' === $post->post_status ) {
+        update_post_meta( $post_ID, '_ap_index', '1' );
+    }
+}

--- a/automatise-plugin/includes/settings.php
+++ b/automatise-plugin/includes/settings.php
@@ -1,0 +1,97 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class AP_Settings {
+
+    public function __construct() {
+        add_action( 'admin_menu', array( $this, 'add_menu' ) );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+    }
+
+    public function add_menu() {
+        add_options_page(
+            __( 'Site Appearance', 'automatise-plugin' ),
+            __( 'Site Appearance', 'automatise-plugin' ),
+            'manage_options',
+            'ap-site-appearance',
+            array( $this, 'settings_page' )
+        );
+    }
+
+    public function register_settings() {
+        register_setting( 'ap_site_options', 'ap_site_logo' );
+        register_setting( 'ap_site_options', 'ap_site_favicon' );
+        register_setting( 'ap_site_options', 'ap_primary_color' );
+        register_setting( 'ap_site_options', 'ap_secondary_color' );
+    }
+
+    public function settings_page() {
+        ?>
+        <div class="wrap">
+            <h1><?php _e( 'Site Appearance Settings', 'automatise-plugin' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php settings_fields( 'ap_site_options' ); ?>
+                <table class="form-table" role="presentation">
+                    <tr>
+                        <th scope="row"><?php _e( 'Logo', 'automatise-plugin' ); ?></th>
+                        <td>
+                            <input type="text" name="ap_site_logo" id="ap_site_logo" value="<?php echo esc_attr( get_option( 'ap_site_logo' ) ); ?>" class="regular-text" />
+                            <button class="button ap-upload" data-target="ap_site_logo"><?php _e( 'Upload', 'automatise-plugin' ); ?></button>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Favicon', 'automatise-plugin' ); ?></th>
+                        <td>
+                            <input type="text" name="ap_site_favicon" id="ap_site_favicon" value="<?php echo esc_attr( get_option( 'ap_site_favicon' ) ); ?>" class="regular-text" />
+                            <button class="button ap-upload" data-target="ap_site_favicon"><?php _e( 'Upload', 'automatise-plugin' ); ?></button>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Primary Color', 'automatise-plugin' ); ?></th>
+                        <td>
+                            <input type="text" name="ap_primary_color" id="ap_primary_color" value="<?php echo esc_attr( get_option( 'ap_primary_color', '#000000' ) ); ?>" class="regular-text" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Secondary Color', 'automatise-plugin' ); ?></th>
+                        <td>
+                            <input type="text" name="ap_secondary_color" id="ap_secondary_color" value="<?php echo esc_attr( get_option( 'ap_secondary_color', '#ffffff' ) ); ?>" class="regular-text" />
+                        </td>
+                    </tr>
+                </table>
+                <?php submit_button(); ?>
+            </form>
+        </div>
+        <script type="text/javascript">
+        jQuery(document).ready(function($){
+            function initUploader(button) {
+                var file_frame;
+                button.on('click', function(e){
+                    e.preventDefault();
+                    var target = $(this).data('target');
+                    if ( file_frame ) {
+                        file_frame.open();
+                        return;
+                    }
+                    file_frame = wp.media.frames.file_frame = wp.media({
+                        title: '<?php _e( 'Select Image', 'automatise-plugin' ); ?>',
+                        button: {text: '<?php _e( 'Use Image', 'automatise-plugin' ); ?>'},
+                        multiple: false
+                    });
+                    file_frame.on('select', function(){
+                        var attachment = file_frame.state().get('selection').first().toJSON();
+                        $('#'+target).val(attachment.url);
+                    });
+                    file_frame.open();
+                });
+            }
+            initUploader($('.ap-upload'));
+        });
+        </script>
+        <?php
+    }
+}
+
+new AP_Settings();


### PR DESCRIPTION
## Summary
- add `automatise-plugin` with settings page, ACF fields, and sample pages

## Testing
- `php -l automatise-plugin/automatise-plugin.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b411ba8832292e4879787f824f5