### PR TITLE
Add Automatise Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-.
+This repository contains a simple WordPress plugin and theme used for testing purposes.

--- a/automatise-plugin/README.md
+++ b/automatise-plugin/README.md
@@ -1,0 +1,15 @@
+# Automatise Plugin
+
+A simple WordPress plugin that provides site appearance settings, custom page fields (using ACF), automatic page creation, and indexing settings.
+
+## Installation
+1. Copy the `automatise-plugin` folder into your WordPress `wp-content/plugins` directory.
+2. Activate the plugin from the WordPress admin plugins screen.
+
+After activation, open **Site Appearance** in the admin sidebar. From this page you can configure logo, favicon, colors and select which pages appear in the header and footer. The same page also contains a button to install and activate the included theme.
+
+## Features
+ - Top-level **Site Appearance** menu for uploading a logo and favicon, picking site colors, choosing header and footer pages, and setting a redirect URL.
+- Custom fields for pages: title, description, content, FAQ, and game block (requires the Advanced Custom Fields plugin).
+- Automatically creates basic pages (`Home`, `About`, and `Contact`) on activation and ensures they are indexed by search engines.
+- Includes a basic theme that can be installed and activated from the settings page.

--- a/automatise-plugin/automatise-plugin.php
+++ b/automatise-plugin/automatise-plugin.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Plugin Name: Automatise Plugin
+ * Description: Adds site settings, custom page fields, and page creation with indexing.
+ * Version: 1.1.0
+ * Author: Codex
+ * Text Domain: automatise-plugin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+// Include required files.
+require_once plugin_dir_path( __FILE__ ) . 'includes/settings.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/acf-fields.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/pages.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/theme-installer.php';
+
+// Activation hook to create pages and enable indexing.
+register_activation_hook( __FILE__, 'ap_activate_plugin' );

--- a/automatise-plugin/includes/acf-fields.php
+++ b/automatise-plugin/includes/acf-fields.php
@@ -1,0 +1,65 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class AP_ACF_Fields {
+
+    public function __construct() {
+        add_action( 'acf/init', array( $this, 'register_fields' ) );
+    }
+
+    public function register_fields() {
+        if ( ! function_exists( 'acf_add_local_field_group' ) ) {
+            return;
+        }
+
+        acf_add_local_field_group( array(
+            'key' => 'group_ap_page_fields',
+            'title' => __( 'Page Custom Fields', 'automatise-plugin' ),
+            'fields' => array(
+                array(
+                    'key' => 'field_ap_page_title',
+                    'label' => __( 'Title', 'automatise-plugin' ),
+                    'name' => 'ap_page_title',
+                    'type' => 'text',
+                ),
+                array(
+                    'key' => 'field_ap_page_description',
+                    'label' => __( 'Description', 'automatise-plugin' ),
+                    'name' => 'ap_page_description',
+                    'type' => 'textarea',
+                ),
+                array(
+                    'key' => 'field_ap_page_content',
+                    'label' => __( 'Content', 'automatise-plugin' ),
+                    'name' => 'ap_page_content',
+                    'type' => 'wysiwyg',
+                ),
+                array(
+                    'key' => 'field_ap_page_faq',
+                    'label' => __( 'FAQ', 'automatise-plugin' ),
+                    'name' => 'ap_page_faq',
+                    'type' => 'wysiwyg',
+                ),
+                array(
+                    'key' => 'field_ap_page_game',
+                    'label' => __( 'Game Block', 'automatise-plugin' ),
+                    'name' => 'ap_page_game_block',
+                    'type' => 'wysiwyg',
+                ),
+            ),
+            'location' => array(
+                array(
+                    array(
+                        'param' => 'post_type',
+                        'operator' => '==',
+                        'value' => 'page',
+                    ),
+                ),
+            ),
+        ) );
+    }
+}
+
+new AP_ACF_Fields();

--- a/automatise-plugin/includes/pages.php
+++ b/automatise-plugin/includes/pages.php
@@ -1,0 +1,60 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function ap_activate_plugin() {
+    $pages = array( 'home', 'about', 'contact' );
+    foreach ( $pages as $slug ) {
+        $existing = get_page_by_path( $slug );
+        if ( ! $existing ) {
+            wp_insert_post( array(
+                'post_title'   => ucfirst( $slug ),
+                'post_name'    => $slug,
+                'post_status'  => 'publish',
+                'post_type'    => 'page',
+            ) );
+        }
+    }
+
+    // Ensure indexing is enabled
+    update_option( 'blog_public', 1 );
+
+    // Flush rewrite rules for redirect slug.
+    flush_rewrite_rules();
+}
+add_action( 'wp_head', 'ap_add_index_meta' );
+function ap_add_index_meta() {
+    echo "\n<meta name='robots' content='index, follow'>\n";
+}
+
+add_action( 'save_post_page', 'ap_set_page_indexing', 10, 3 );
+function ap_set_page_indexing( $post_ID, $post, $update ) {
+    if ( 'publish' === $post->post_status ) {
+        update_post_meta( $post_ID, '_ap_index', '1' );
+    }
+}
+
+add_action( 'init', 'ap_register_redirect' );
+function ap_register_redirect() {
+    $slug = trim( get_option( 'ap_redirect_slug' ) );
+    if ( $slug ) {
+        add_rewrite_rule( '^' . preg_quote( $slug, '/' ) . '/?$', 'index.php?ap_redirect=1', 'top' );
+    }
+}
+
+add_action( 'template_redirect', 'ap_handle_redirect' );
+function ap_handle_redirect() {
+    if ( get_query_var( 'ap_redirect' ) ) {
+        $target = get_option( 'ap_redirect_target' );
+        if ( $target ) {
+            wp_redirect( esc_url_raw( $target ) );
+            exit;
+        }
+    }
+}
+
+add_filter( 'query_vars', function( $vars ) {
+    $vars[] = 'ap_redirect';
+    return $vars;
+} );

--- a/automatise-plugin/includes/settings.php
+++ b/automatise-plugin/includes/settings.php
@@ -1,0 +1,187 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class AP_Settings {
+
+    public function __construct() {
+        add_action( 'admin_menu', array( $this, 'add_menu' ) );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+    }
+
+    public function add_menu() {
+        add_menu_page(
+            __( 'Site Appearance', 'automatise-plugin' ),
+            __( 'Site Appearance', 'automatise-plugin' ),
+            'manage_options',
+            'ap-site-appearance',
+            array( $this, 'settings_page' ),
+            'dashicons-admin-customizer',
+            81
+        );
+    }
+
+    public function register_settings() {
+        register_setting( 'ap_site_options', 'ap_site_logo' );
+        register_setting( 'ap_site_options', 'ap_site_favicon' );
+        register_setting( 'ap_site_options', 'ap_primary_color' );
+        register_setting( 'ap_site_options', 'ap_secondary_color' );
+        register_setting( 'ap_site_options', 'ap_font_color' );
+        register_setting( 'ap_site_options', 'ap_button_color' );
+        register_setting( 'ap_site_options', 'ap_button_text_color' );
+        register_setting( 'ap_site_options', 'ap_header_color' );
+        register_setting( 'ap_site_options', 'ap_header_text_color' );
+        register_setting( 'ap_site_options', 'ap_footer_color' );
+        register_setting( 'ap_site_options', 'ap_footer_text_color' );
+        register_setting( 'ap_site_options', 'ap_footer_copy' );
+        register_setting( 'ap_site_options', 'ap_header_pages', array( 'sanitize_callback' => array( $this, 'sanitize_array' ) ) );
+        register_setting( 'ap_site_options', 'ap_footer_pages', array( 'sanitize_callback' => array( $this, 'sanitize_array' ) ) );
+        register_setting( 'ap_site_options', 'ap_redirect_slug' );
+        register_setting( 'ap_site_options', 'ap_redirect_target' );
+    }
+
+    public function enqueue_scripts() {
+        wp_enqueue_media();
+    }
+
+    public function sanitize_array( $value ) {
+        return array_map( 'absint', (array) $value );
+    }
+
+    public function settings_page() {
+        if ( isset( $_GET['ap_install_theme'] ) ) {
+            AP_Theme_Installer::install_and_activate();
+            echo '<div class="updated notice"><p>' . esc_html__( 'Automatise Theme installed and activated.', 'automatise-plugin' ) . '</p></div>';
+        }
+        ?>
+        <div class="wrap">
+            <h1><?php _e( 'Site Appearance Settings', 'automatise-plugin' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php settings_fields( 'ap_site_options' ); ?>
+                <table class="form-table" role="presentation">
+                    <tr>
+                        <th scope="row"><?php _e( 'Logo', 'automatise-plugin' ); ?></th>
+                        <td>
+                            <input type="text" name="ap_site_logo" id="ap_site_logo" value="<?php echo esc_attr( get_option( 'ap_site_logo' ) ); ?>" class="regular-text" />
+                            <button class="button ap-upload" data-target="ap_site_logo"><?php _e( 'Upload', 'automatise-plugin' ); ?></button>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Favicon', 'automatise-plugin' ); ?></th>
+                        <td>
+                            <input type="text" name="ap_site_favicon" id="ap_site_favicon" value="<?php echo esc_attr( get_option( 'ap_site_favicon' ) ); ?>" class="regular-text" />
+                            <button class="button ap-upload" data-target="ap_site_favicon"><?php _e( 'Upload', 'automatise-plugin' ); ?></button>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Primary Color', 'automatise-plugin' ); ?></th>
+                        <td>
+                            <input type="text" name="ap_primary_color" id="ap_primary_color" value="<?php echo esc_attr( get_option( 'ap_primary_color', '#000000' ) ); ?>" class="regular-text" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Secondary Color', 'automatise-plugin' ); ?></th>
+                        <td>
+                            <input type="text" name="ap_secondary_color" id="ap_secondary_color" value="<?php echo esc_attr( get_option( 'ap_secondary_color', '#ffffff' ) ); ?>" class="regular-text" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Font Color', 'automatise-plugin' ); ?></th>
+                        <td>
+                            <input type="text" name="ap_font_color" id="ap_font_color" value="<?php echo esc_attr( get_option( 'ap_font_color', '#000000' ) ); ?>" class="regular-text" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Button Color', 'automatise-plugin' ); ?></th>
+                        <td>
+                            <input type="text" name="ap_button_color" id="ap_button_color" value="<?php echo esc_attr( get_option( 'ap_button_color', '#000000' ) ); ?>" class="regular-text" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Button Text Color', 'automatise-plugin' ); ?></th>
+                        <td>
+                            <input type="text" name="ap_button_text_color" id="ap_button_text_color" value="<?php echo esc_attr( get_option( 'ap_button_text_color', '#ffffff' ) ); ?>" class="regular-text" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Header Background', 'automatise-plugin' ); ?></th>
+                        <td><input type="text" name="ap_header_color" id="ap_header_color" value="<?php echo esc_attr( get_option( 'ap_header_color', '#ffffff' ) ); ?>" class="regular-text" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Header Text Color', 'automatise-plugin' ); ?></th>
+                        <td><input type="text" name="ap_header_text_color" id="ap_header_text_color" value="<?php echo esc_attr( get_option( 'ap_header_text_color', '#000000' ) ); ?>" class="regular-text" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Footer Background', 'automatise-plugin' ); ?></th>
+                        <td><input type="text" name="ap_footer_color" id="ap_footer_color" value="<?php echo esc_attr( get_option( 'ap_footer_color', '#ffffff' ) ); ?>" class="regular-text" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Footer Text Color', 'automatise-plugin' ); ?></th>
+                        <td><input type="text" name="ap_footer_text_color" id="ap_footer_text_color" value="<?php echo esc_attr( get_option( 'ap_footer_text_color', '#000000' ) ); ?>" class="regular-text" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Footer Copyright', 'automatise-plugin' ); ?></th>
+                        <td><input type="text" name="ap_footer_copy" id="ap_footer_copy" value="<?php echo esc_attr( get_option( 'ap_footer_copy' ) ); ?>" class="regular-text" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Header Pages', 'automatise-plugin' ); ?></th>
+                        <td>
+                            <select name="ap_header_pages[]" multiple style="height:100px;width: 250px;">
+                                <?php echo walk_page_dropdown_tree( get_pages(), 0, array( 'selected' => get_option( 'ap_header_pages', array() ) ) ); ?>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Footer Pages', 'automatise-plugin' ); ?></th>
+                        <td>
+                            <select name="ap_footer_pages[]" multiple style="height:100px;width: 250px;">
+                                <?php echo walk_page_dropdown_tree( get_pages(), 0, array( 'selected' => get_option( 'ap_footer_pages', array() ) ) ); ?>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Redirect Slug', 'automatise-plugin' ); ?></th>
+                        <td><input type="text" name="ap_redirect_slug" id="ap_redirect_slug" value="<?php echo esc_attr( get_option( 'ap_redirect_slug', 'redirect' ) ); ?>" class="regular-text" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e( 'Redirect Target URL', 'automatise-plugin' ); ?></th>
+                        <td><input type="url" name="ap_redirect_target" id="ap_redirect_target" value="<?php echo esc_attr( get_option( 'ap_redirect_target' ) ); ?>" class="regular-text" /></td>
+                    </tr>
+                </table>
+                <?php submit_button(); ?>
+                <a href="<?php echo esc_url( admin_url( 'admin.php?page=ap-site-appearance&ap_install_theme=1' ) ); ?>" class="button button-secondary" style="margin-top:10px;"><?php _e( 'Install Automatise Theme', 'automatise-plugin' ); ?></a>
+            </form>
+        </div>
+        <script type="text/javascript">
+        jQuery(document).ready(function($){
+            function initUploader(button) {
+                var file_frame;
+                button.on('click', function(e){
+                    e.preventDefault();
+                    var target = $(this).data('target');
+                    if ( file_frame ) {
+                        file_frame.open();
+                        return;
+                    }
+                    file_frame = wp.media.frames.file_frame = wp.media({
+                        title: '<?php _e( 'Select Image', 'automatise-plugin' ); ?>',
+                        button: {text: '<?php _e( 'Use Image', 'automatise-plugin' ); ?>'},
+                        multiple: false
+                    });
+                    file_frame.on('select', function(){
+                        var attachment = file_frame.state().get('selection').first().toJSON();
+                        $('#'+target).val(attachment.url);
+                    });
+                    file_frame.open();
+                });
+            }
+            initUploader($('.ap-upload'));
+        });
+        </script>
+        <?php
+    }
+}
+
+new AP_Settings();

--- a/automatise-plugin/includes/theme-installer.php
+++ b/automatise-plugin/includes/theme-installer.php
@@ -1,0 +1,35 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class AP_Theme_Installer {
+
+    public static function install_and_activate() {
+        $theme_dir = plugin_dir_path( __DIR__ ) . 'theme/ap-theme';
+        $dest_dir  = WP_CONTENT_DIR . '/themes/ap-theme';
+        if ( ! file_exists( $dest_dir ) ) {
+            self::recurse_copy( $theme_dir, $dest_dir );
+        }
+        if ( function_exists( 'switch_theme' ) ) {
+            switch_theme( 'ap-theme' );
+        }
+    }
+
+    private static function recurse_copy( $src, $dst ) {
+        $dir = opendir( $src );
+        if ( ! file_exists( $dst ) ) {
+            mkdir( $dst, 0755, true );
+        }
+        while ( false !== ( $file = readdir( $dir ) ) ) {
+            if ( ( $file !== '.' ) && ( $file !== '..' ) ) {
+                if ( is_dir( "$src/$file" ) ) {
+                    self::recurse_copy( "$src/$file", "$dst/$file" );
+                } else {
+                    copy( "$src/$file", "$dst/$file" );
+                }
+            }
+        }
+        closedir( $dir );
+    }
+}

--- a/automatise-plugin/theme/ap-theme/footer.php
+++ b/automatise-plugin/theme/ap-theme/footer.php
@@ -1,0 +1,22 @@
+</main>
+<footer style="background: <?php echo esc_attr( get_option( 'ap_footer_color', '#ffffff' ) ); ?>; color: <?php echo esc_attr( get_option( 'ap_footer_text_color', '#000000' ) ); ?>;">
+    <nav class="footer-menu">
+        <ul>
+            <?php
+            $pages = get_option( 'ap_footer_pages', array() );
+            foreach ( (array) $pages as $page_id ) {
+                $page = get_post( $page_id );
+                if ( $page ) {
+                    echo '<li><a href="' . esc_url( get_permalink( $page ) ) . '">' . esc_html( $page->post_title ) . '</a></li>';
+                }
+            }
+            ?>
+        </ul>
+    </nav>
+    <div class="copyright">
+        <?php echo esc_html( get_option( 'ap_footer_copy' ) ); ?>
+    </div>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/automatise-plugin/theme/ap-theme/functions.php
+++ b/automatise-plugin/theme/ap-theme/functions.php
@@ -1,0 +1,18 @@
+<?php
+function ap_theme_setup() {
+    add_theme_support( 'title-tag' );
+}
+add_action( 'after_setup_theme', 'ap_theme_setup' );
+
+function ap_theme_menus() {
+    register_nav_menus( array(
+        'header' => __( 'Header Menu', 'ap-theme' ),
+        'footer' => __( 'Footer Menu', 'ap-theme' ),
+    ) );
+}
+add_action( 'init', 'ap_theme_menus' );
+
+function ap_theme_styles() {
+    wp_enqueue_style( 'ap-theme-style', get_stylesheet_uri() );
+}
+add_action( 'wp_enqueue_scripts', 'ap_theme_styles' );

--- a/automatise-plugin/theme/ap-theme/header.php
+++ b/automatise-plugin/theme/ap-theme/header.php
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<header style="background: <?php echo esc_attr( get_option( 'ap_header_color', '#ffffff' ) ); ?>; color: <?php echo esc_attr( get_option( 'ap_header_text_color', '#000000' ) ); ?>;">
+    <div class="site-branding">
+        <?php if ( $logo = get_option( 'ap_site_logo' ) ) : ?>
+            <a href="<?php echo esc_url( home_url( '/' ) ); ?>"><img src="<?php echo esc_url( $logo ); ?>" alt="<?php bloginfo( 'name' ); ?>"></a>
+        <?php else : ?>
+            <h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a></h1>
+        <?php endif; ?>
+    </div>
+    <nav class="header-menu">
+        <ul>
+            <?php
+            $pages = get_option( 'ap_header_pages', array() );
+            foreach ( (array) $pages as $page_id ) {
+                $page = get_post( $page_id );
+                if ( $page ) {
+                    echo '<li><a href="' . esc_url( get_permalink( $page ) ) . '">' . esc_html( $page->post_title ) . '</a></li>';
+                }
+            }
+            ?>
+        </ul>
+    </nav>
+    <div class="header-buttons">
+        <a href="<?php echo esc_url( wp_login_url() ); ?>" class="button login"><?php _e( 'Log in', 'ap-theme' ); ?></a>
+        <a href="<?php echo esc_url( wp_registration_url() ); ?>" class="button register"><?php _e( 'Register', 'ap-theme' ); ?></a>
+    </div>
+</header>
+<main>

--- a/automatise-plugin/theme/ap-theme/index.php
+++ b/automatise-plugin/theme/ap-theme/index.php
@@ -1,0 +1,10 @@
+<?php get_header(); ?>
+<?php
+if ( have_posts() ) :
+    while ( have_posts() ) :
+        the_post();
+        the_content();
+    endwhile;
+endif;
+?>
+<?php get_footer(); ?>

--- a/automatise-plugin/theme/ap-theme/style.css
+++ b/automatise-plugin/theme/ap-theme/style.css
@@ -1,0 +1,7 @@
+/*
+Theme Name: Automatise Theme
+Theme URI: https://example.com
+Author: Codex
+Version: 1.0
+Description: Basic theme installed via Automatise Plugin.
+*/


### PR DESCRIPTION
## Summary
- add Automatise plugin with theme installer and extended settings

## Testing
- `php -l automatise-plugin/automatise-plugin.php` *(fails: `php` not found)*


------
https://chatgpt.com/codex/tasks/task_e_683f4b411ba8832292e4879787f824f5